### PR TITLE
Check isatty() to decide if colors are supported (#127)

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -216,6 +216,9 @@ namespace loguru
 			}
 			return false;
 		#else
+			if (!isatty(STDERR_FILENO)) {
+				return false;
+			}
 			if (const char* term = getenv("TERM")) {
 				return 0 == strcmp(term, "cygwin")
 					|| 0 == strcmp(term, "linux")


### PR DESCRIPTION
* Check isatty() to decide if colors are supported

Currently, the type of terminal ($TERM) is checked in s_terminal_has_color() to decide if colors are supported. However, the stderr can be redirected to a file or another process which doesn't support colors. To check if stderr is being received by a terminal, at least the isatty() POSIX function must be used.

* Added braces to isatty() check